### PR TITLE
Fix mixin being added to launch arguments twice

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,6 @@ loom {
             property("mixin.debug", "true")
             property("asmhelper.verbose", "true")
             arg("--tweakClass", "org.spongepowered.asm.launch.MixinTweaker")
-            arg("--mixin", "mixins.$modid.json")
         }
     }
     forge {


### PR DESCRIPTION
The loom mixin extension adds the mixin to the launch arguments automatically. Adding it in the launch config causes the argument to be added twice, which breaks launch logic. Adding the argument twice causes the first command line argument after the second mixin addition to be parsed incorrectly and therefore ignored.

Please see `net.minecraftforge.fml.common.launcher.FMLTweaker` line 79.
If classifier is set to a pre-existing value instead of null, the next argument will be ignored.